### PR TITLE
Add AB diarization script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # Speech-to-text
-根据上传的语音文件，自动识别成AB对话
+
+根据上传的语音文件，自动识别并输出 AB 对话形式。
+
+## 使用说明
+
+1. 安装依赖：
+   ```bash
+   pip install whisper pyannote.audio
+   ```
+   `pyannote.audio` 需要额外的依赖，可参考其官方文档进行安装。
+
+2. 运行脚本：
+   ```bash
+   python ab_transcribe.py <audio_path> --output dialog.txt
+   ```
+
+脚本会调用 `whisper` 进行转写，并通过 `pyannote.audio` 完成说话人分离，最终按 “A:” / “B:” 的形式保存到指定文件。
+

--- a/ab_transcribe.py
+++ b/ab_transcribe.py
@@ -1,0 +1,59 @@
+import argparse
+from dataclasses import dataclass
+from typing import List, Tuple
+
+import whisper
+from pyannote.audio import Pipeline
+
+@dataclass
+class Segment:
+    start: float
+    end: float
+    text: str
+    speaker: str
+
+
+def transcribe(audio_path: str) -> List[Segment]:
+    """Transcribe audio and assign speaker labels."""
+    model = whisper.load_model("base")
+    result = model.transcribe(audio_path, language="zh")
+
+    pipeline = Pipeline.from_pretrained("pyannote/speaker-diarization")
+    diarization = pipeline(audio_path)
+
+    segments: List[Segment] = []
+    for segment in result["segments"]:
+        start = segment["start"]
+        end = segment["end"]
+        text = segment["text"].strip()
+        speaker = "A"
+        for turn in diarization.itertracks(yield_label=True):
+            if start >= turn[0].start and end <= turn[0].end:
+                speaker = "A" if turn[2] == "SPEAKER_00" else "B"
+                break
+        segments.append(Segment(start, end, text, speaker))
+    return segments
+
+
+def format_dialog(segments: List[Segment]) -> str:
+    lines = []
+    for seg in segments:
+        lines.append(f"{seg.speaker}: {seg.text}")
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="转写语音并标记AB对话")
+    parser.add_argument("audio", help="音频文件路径")
+    parser.add_argument("--output", help="输出文本文件", default="output.txt")
+    args = parser.parse_args()
+
+    segments = transcribe(args.audio)
+    dialog = format_dialog(segments)
+    with open(args.output, "w", encoding="utf-8") as f:
+        f.write(dialog)
+    print(f"结果已保存到 {args.output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `ab_transcribe.py` to transcribe audio and label two speakers as A/B
- document usage in README

## Testing
- `python -m py_compile ab_transcribe.py`


------
https://chatgpt.com/codex/tasks/task_e_684706ed1b548320bd4d45ada2aa7182